### PR TITLE
Allow wp-signup.php access if enabled

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -33,6 +33,13 @@ function redirect_user() {
 	if ( ! empty( $GLOBALS['pagenow'] ) && $GLOBALS['pagenow'] === 'wp-login.php' ) {
 		return;
 	}
+	
+	// Allow signups if enabled.
+	if ( ! empty( $GLOBALS['pagenow'] ) && $GLOBALS['pagenow'] === 'wp-signup.php' ) {
+		if ( is_multisite() && get_site_option( 'registration', 'none' ) !== 'none' ) {
+			return;
+		}
+	}
 
 	if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
 		return;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -33,7 +33,7 @@ function redirect_user() {
 	if ( ! empty( $GLOBALS['pagenow'] ) && $GLOBALS['pagenow'] === 'wp-login.php' ) {
 		return;
 	}
-	
+
 	// Allow signups if enabled.
 	if ( ! empty( $GLOBALS['pagenow'] ) && $GLOBALS['pagenow'] === 'wp-signup.php' ) {
 		if ( is_multisite() && get_site_option( 'registration', 'none' ) !== 'none' ) {


### PR DESCRIPTION
Right now signups can be enabled but access to `wp-signup.php` is blocked.

Fixes #7 