### PR TITLE
Allow wp-activate and wp-signup through login wall

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -32,10 +32,21 @@ function redirect_user() {
 
 	$page = $GLOBALS['pagenow'] ?? null;
 	$allowed = [
-		'wp-activate.php',
 		'wp-login.php',
-		'wp-signup.php',
 	];
+
+	/**
+	 * Filter pages allowed to pass through the login wall.
+	 *
+	 * Filters which pages are allowed through the login wall. "Pages" in this
+	 * sense is the value of the `$pagenow` global.
+	 *
+	 * By default, only the login form is allowed to pass through; to allow
+	 * registration on multisite, `wp-activate.php` and `wp-signup.php` need
+	 * to be allowed too. Note that these use your theme, so may leak private
+	 * theme data.
+	 */
+	$allowed = apply_filters( 'hm-require-login.allowed_pages', $allowed, $page );
 
 	if ( $page && in_array( $page, $allowed, true ) ) {
 		return;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -30,7 +30,14 @@ function redirect_user() {
 		}
 	}
 
-	if ( ! empty( $GLOBALS['pagenow'] ) && $GLOBALS['pagenow'] === 'wp-login.php' ) {
+	$page = $GLOBALS['pagenow'] ?? null;
+	$allowed = [
+		'wp-activate.php',
+		'wp-login.php',
+		'wp-signup.php',
+	];
+
+	if ( $page && in_array( $page, $allowed, true ) ) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes multisite signup process by allowing wp-activate and wp-signup to pass through the login wall.

Note: these pages both show the theme, so this *could* be a leak of data.