### PR TITLE
Dont exit early on OPTIONS requests

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -26,7 +26,6 @@ function redirect_user() {
 			header( 'Access-Control-Allow-Credentials: true' );
 			header( 'Access-Control-Allow-Headers: Authorization, Content-Type' );
 			header( 'Access-Control-Allow-Expose-Headers: X-WP-Total, X-WP-TotalPages' );
-			exit;
 		}
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -57,6 +57,7 @@ function redirect_user() {
 				header( 'Access-Control-Allow-Credentials: true' );
 				header( 'Access-Control-Allow-Headers: Authorization, Content-Type' );
 				header( 'Access-Control-Allow-Expose-Headers: X-WP-Total, X-WP-TotalPages' );
+				exit;
 			}
 		}
 		http_response_code( 401 );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -15,20 +15,6 @@ function redirect_user() {
 		return;
 	}
 
-	/*
-	 * Allow pre-flight checks to the REST API.
-	 */
-	if ( 'OPTIONS' === $_SERVER['REQUEST_METHOD'] && strpos( $_SERVER['REQUEST_URI'], '/' . rest_get_url_prefix() ) === 0 ) {
-		$origin = get_http_origin();
-		if ( $origin ) {
-			header( 'Access-Control-Allow-Origin: ' . esc_url_raw( $origin ) );
-			header( 'Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, DELETE' );
-			header( 'Access-Control-Allow-Credentials: true' );
-			header( 'Access-Control-Allow-Headers: Authorization, Content-Type' );
-			header( 'Access-Control-Allow-Expose-Headers: X-WP-Total, X-WP-TotalPages' );
-		}
-	}
-
 	$page = $GLOBALS['pagenow'] ?? null;
 	$allowed = [
 		'wp-login.php',
@@ -60,6 +46,19 @@ function redirect_user() {
 	}
 
 	if ( strpos( $_SERVER['REQUEST_URI'], '/' . rest_get_url_prefix() ) === 0 ) {
+		/**
+		 * Allow pre-flight checks to the REST API.
+		 */
+		if ( 'OPTIONS' === $_SERVER['REQUEST_METHOD'] ) {
+			$origin = get_http_origin();
+			if ( $origin ) {
+				header( 'Access-Control-Allow-Origin: ' . esc_url_raw( $origin ) );
+				header( 'Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, DELETE' );
+				header( 'Access-Control-Allow-Credentials: true' );
+				header( 'Access-Control-Allow-Headers: Authorization, Content-Type' );
+				header( 'Access-Control-Allow-Expose-Headers: X-WP-Total, X-WP-TotalPages' );
+			}
+		}
 		http_response_code( 401 );
 		exit;
 	} else {


### PR DESCRIPTION
OPTIONS requests should be able to return the available schema / routes for a given endpoint in the body. This was causing problems with pre-flight checks for logged in users because of the early exit in the code.

Fixes https://github.com/humanmade/altis-security/issues/76