### PR TITLE
Fix application passwords

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -1,13 +1,23 @@
 <?php
+/**
+ * Require Login functions.
+ *
+ * phpcs:disable WordPress.NamingConventions.ValidHookName
+ */
 
 namespace HM\Require_Login;
 
+/**
+ * Redirects the user to login.
+ *
+ * @return void
+ */
 function redirect_user() {
 	if ( ( defined( 'WP_CLI' ) && WP_CLI ) || defined( 'DOING_CRON' ) ) {
 		return;
 	}
 
-	/*
+	/**
 	 * Allow access to the connect oauth auth
 	 * to go through.
 	 */

--- a/plugin.php
+++ b/plugin.php
@@ -4,11 +4,16 @@
  * Description: Only allow the site to be accessed by logged in users.
  * Author: Human Made Limited
  * Version: 1.0.4
- * Author URI: http://hmn.md
+ * Author URI: https://humanmade.com
  */
 
 namespace HM\Require_Login;
 
 require_once __DIR__ . '/inc/namespace.php';
 
-add_action( 'template_redirect', __NAMESPACE__ . '\\redirect_user', 1 );
+add_action( 'init', __NAMESPACE__ . '\\redirect_user', 999 );
+
+// Ensure application passwords can be verified early for REST API requests.
+if ( strpos( $_SERVER['REQUEST_URI'], '/' . rest_get_url_prefix() ) !== false ) {
+	add_filter( 'application_password_is_api_request', '__return_true' );
+}

--- a/plugin.php
+++ b/plugin.php
@@ -14,6 +14,6 @@ require_once __DIR__ . '/inc/namespace.php';
 add_action( 'init', __NAMESPACE__ . '\\redirect_user', 999 );
 
 // Ensure application passwords can be verified early for REST API requests.
-if ( strpos( $_SERVER['REQUEST_URI'], '/' . rest_get_url_prefix() ) !== false ) {
+if ( strpos( $_SERVER['REQUEST_URI'], '/' . rest_get_url_prefix() ) === 0 ) {
 	add_filter( 'application_password_is_api_request', '__return_true' );
 }

--- a/plugin.php
+++ b/plugin.php
@@ -1,12 +1,11 @@
 <?php
-
-/*
-Plugin Name: HM Require Login
-Description: Only allow the site to be accessed by logged in users.
-Author: Human Made Limited
-Version: 1.0.4
-Author URI: http://hmn.md
-*/
+/**
+ * Plugin Name: HM Require Login
+ * Description: Only allow the site to be accessed by logged in users.
+ * Author: Human Made Limited
+ * Version: 1.0.4
+ * Author URI: http://hmn.md
+ */
 
 namespace HM\Require_Login;
 

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
 Plugin Name: HM Require Login
 Description: Only allow the site to be accessed by logged in users.
 Author: Human Made Limited
-Version: 1.0.3
+Version: 1.0.4
 Author URI: http://hmn.md
 */
 
@@ -12,4 +12,4 @@ namespace HM\Require_Login;
 
 require_once __DIR__ . '/inc/namespace.php';
 
-add_action( 'init', __NAMESPACE__ . '\\redirect_user', 999 );
+add_action( 'template_redirect', __NAMESPACE__ . '\\redirect_user', 1 );


### PR DESCRIPTION
The `template_redirect` action is a more appropriate hook for this functionality.

Specifically however with the addition of application passwords in WordPress 5.6 the `init` is too early for the REST API server to have been instantiated or for the application password to have been processed in a REST API request context.