### PR TITLE
Prevent require login from blocking robots.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
             Script that requires users to be logged in view site.
 		</td>
 		<td align="right" width="20%">
-			Version 1.0
+			Version 1.0.5
 		</td>
 	</tr>
 	<tr>

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -49,6 +49,7 @@ function redirect_user() {
 	}
 
 	if ( $_SERVER['REQUEST_URI'] && in_array( $_SERVER['REQUEST_URI'] , $allowed, true ) ){
+		add_filter( 'robots_txt', __NAMESPACE__ . '\\create_robots_file' );
 		return;
 	}
 
@@ -80,4 +81,16 @@ function redirect_user() {
 	} else {
 		auth_redirect();
 	}
+}
+
+/**
+ * Filters the robots.txt output.
+ *
+ * @param string $output The robots.txt output.
+ * @return string The robots.txt output.
+ */
+function create_robots_file( string $output ) {
+	$output = "User-agent: *\n";
+	$output .= "Disallow: /\n";
+	return $output;
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -28,7 +28,7 @@ function redirect_user() {
 	$page = $GLOBALS['pagenow'] ?? null;
 	$allowed = [
 		'wp-login.php',
-		'/robots.txt'
+		'/robots.txt',
 	];
 
 	/**
@@ -48,7 +48,7 @@ function redirect_user() {
 		return;
 	}
 
-	if ( $_SERVER['REQUEST_URI'] && in_array( $_SERVER['REQUEST_URI'] , $allowed, true ) ){
+	if ( $_SERVER['REQUEST_URI'] && in_array( $_SERVER['REQUEST_URI'], $allowed, true ) ) {
 		add_filter( 'robots_txt', __NAMESPACE__ . '\\create_robots_file' );
 		return;
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -28,6 +28,7 @@ function redirect_user() {
 	$page = $GLOBALS['pagenow'] ?? null;
 	$allowed = [
 		'wp-login.php',
+		'/robots.txt'
 	];
 
 	/**
@@ -44,6 +45,10 @@ function redirect_user() {
 	$allowed = apply_filters( 'hm-require-login.allowed_pages', $allowed, $page );
 
 	if ( $page && in_array( $page, $allowed, true ) ) {
+		return;
+	}
+
+	if ( $_SERVER['REQUEST_URI'] && in_array( $_SERVER['REQUEST_URI'] , $allowed, true ) ){
 		return;
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -25,10 +25,17 @@ function redirect_user() {
 		return;
 	}
 
+	/**
+	 * Allow access to the robots.txt file.
+	 */
+	if ( ( $_SERVER['REQUEST_URI'] ?? '' ) === '/robots.txt' ) {
+		add_filter( 'robots_txt', __NAMESPACE__ . '\\create_robots_file' );
+		return;
+	}
+
 	$page = $GLOBALS['pagenow'] ?? null;
 	$allowed = [
 		'wp-login.php',
-		'/robots.txt',
 	];
 
 	/**
@@ -45,11 +52,6 @@ function redirect_user() {
 	$allowed = apply_filters( 'hm-require-login.allowed_pages', $allowed, $page );
 
 	if ( $page && in_array( $page, $allowed, true ) ) {
-		return;
-	}
-
-	if ( $_SERVER['REQUEST_URI'] && in_array( $_SERVER['REQUEST_URI'], $allowed, true ) ) {
-		add_filter( 'robots_txt', __NAMESPACE__ . '\\create_robots_file' );
 		return;
 	}
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: HM Require Login
  * Description: Only allow the site to be accessed by logged in users.
  * Author: Human Made Limited
- * Version: 1.0.4
+ * Version: 1.0.5
  * Author URI: https://humanmade.com
  */
 


### PR DESCRIPTION
Require login blocks access to robots.txt which is generated by WP.

This PR allows access to robots.txt when require login is enabled.

This PR also sets the robots.txt file to return:
```
User-agent: *
Disallow: /
```

### Steps to confirm:
1. Enable `Require login` on your environment.
2. Confirm `Require login` is active by trying to view a page on the site.
3. Once enabled, try access the `/robots.txt` file and you will see the below:
```
User-agent: *
Disallow: /
```

[Original issue #154](https://github.com/humanmade/altis-security/issues/154)