### PR TITLE
Filter the X-Redirect-By header value

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -81,8 +81,19 @@ function redirect_user() {
 		http_response_code( 401 );
 		exit;
 	} else {
+		add_filter( 'x_redirect_by', __NAMESPACE__ . '\\filter_x_redirect_by', 10, 0 );
 		auth_redirect();
+		remove_filter( 'x_redirect_by', __NAMESPACE__ . '\\filter_x_redirect_by', 10 );
 	}
+}
+
+/**
+ * Filters the X-Redirect-By header.
+ *
+ * @return string The application doing the redirect.
+ */
+function filter_x_redirect_by(): string {
+	return 'WordPress/Require Login';
 }
 
 /**


### PR DESCRIPTION
I was debugging a mystery redirect issue which turned out to be caused by HM Require Login redirecting to the login screen via `auth_redirect()`. WordPress sets an `X-Redirect-By` header during redirects, setting this to a more specific value aids with debugging.

## Screenshot

<img width="429" alt="" src="https://user-images.githubusercontent.com/208434/188729781-318ee0b4-d3d5-46dc-ae4f-02a813bbd1f3.png">